### PR TITLE
add typed-ast for py37, pip check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -24,13 +24,17 @@ requirements:
     - lazy-object-proxy
     - six
     - wrapt
-    - typed-ast   # [py<37]
+    - typed-ast   # [py<38]
     - typing      # [py<35]
 
 test:
+  requires:
+    - pip
   imports:
     - astroid
     - astroid.modutils
+  commands:
+    - python -m pip check
 
 about:
   home: https://www.astroid.org/


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- includes `typed-ast` for py37 
  - found via `pip check` in https://github.com/conda-forge/tox-feedstock/pull/51
- also adds `pip check` for The Future