### PR TITLE
Expand dependencies for osx-arm64 compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b31c92f545517dcc452f284bc9c044050862fbe6d93d2b3de4a215a6b384bf0d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -21,9 +21,9 @@ requirements:
   run:
     - python
     - setuptools
-    - lazy-object-proxy ==1.4.*
+    - lazy-object-proxy >=1.4,<2
     - six >=1.12,<2
-    - wrapt ==1.11.*
+    - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<1.5  # [py<38]
 
 test:


### PR DESCRIPTION
This PR allows building astroid for osx-arm64 by adjusting the dependencies of `wrapt` and `lazy-object-proxy`.
It is required as the earliest versions available for osx-arm64 of `wrapt(=1.12.1)` and `lazy-object-proxy(=1.5.2)` are currently excluded by the recipe.
These changes were also made for astroid 2.5 on github.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
