### PR TITLE
Clean up dependencies for astroid 3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -23,11 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - lazy-object-proxy >=1.4.0
     - typing-extensions >=4.0.0  # [py<311]
-    - typed-ast <2.0,>=1.4.0  # [py<38]
-    - wrapt <2,>=1.11  # [py<311]
-    - wrapt <2,>=1.14  # [py>=311]
 
 test:
   requires:


### PR DESCRIPTION
wrapt, lazy-object-proxy, and typed-ast were dropped as dependencies.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
